### PR TITLE
 Allow each typed clients to use different authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2018-12-02
+
+### GSS.Authorization.OAuth2 1.3.0
+
+- Add Authorizer as abstract class of IAuthorizer to inject HttpClient
+- Make all authorizers as typed clients
+- Obsolete AuthorizerHttpClient
+
+### GSS.Authorization.OAuth2.HttpClient 1.3.0
+
+- Allow each typed clients to use different authorizer
+
 ## 2018-12-01
 
 ### GSS.Authorization.OAuth2 1.2.0

--- a/samples/OAuth2HttpClientSample/Program.cs
+++ b/samples/OAuth2HttpClientSample/Program.cs
@@ -47,19 +47,29 @@ namespace OAuth2HttpClientSample
 
             if (Configuration.GetValue("OAuth2:GrantFlow", "ResourceOwnerCredentials").Equals("ClientCredentials"))
             {
-                // override the IAuthorizer
-                services.AddTransient<IAuthorizer, ClientCredentialsAuthorizer>();
+                services.AddOAuth2HttpClient<OAuth2HttpClient, ClientCredentialsAuthorizer>((resolver, options) =>
+                {
+                    ConfigureAuthorizerOptions(options);
+                });
             }
-
-            services.AddOAuth2HttpClient<OAuth2HttpClient, ResourceOwnerCredentialsAuthorizer>((resolver, options) =>
+            else
             {
-                var configuration = resolver.GetRequiredService<IConfiguration>();
-                options.AccessTokenEndpoint = configuration.GetValue<Uri>("OAuth2:AccessTokenEndpoint");
-                options.ClientId = configuration["OAuth2:ClientId"];
-                options.ClientSecret = configuration["OAuth2:ClientSecret"];
-                options.Credentials = new NetworkCredential(configuration["OAuth2:Credentials:UserName"], configuration["OAuth2:Credentials:Password"]);
-                options.Scopes = configuration.GetSection("OAuth2:Scopes").Get<IEnumerable<string>>();
-            });
+                services.AddOAuth2HttpClient<OAuth2HttpClient, ResourceOwnerCredentialsAuthorizer>((resolver, options) =>
+                {
+                    ConfigureAuthorizerOptions(options);
+                });
+            }
+        }
+
+        private static void ConfigureAuthorizerOptions(AuthorizerOptions options)
+        {
+            options.AccessTokenEndpoint = Configuration.GetValue<Uri>("OAuth2:AccessTokenEndpoint");
+            options.ClientId = Configuration["OAuth2:ClientId"];
+            options.ClientSecret = Configuration["OAuth2:ClientSecret"];
+            options.Credentials = new NetworkCredential(
+                Configuration["OAuth2:Credentials:UserName"],
+                Configuration["OAuth2:Credentials:Password"]);
+            options.Scopes = Configuration.GetSection("OAuth2:Scopes").Get<IEnumerable<string>>();
         }
     }
 }

--- a/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
+++ b/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>OAuth 2.0 authorized HttpClient, friendly with HttpClientFactory</Description>
     <PackageTags>OAuth;OAuth2;HttpClient;HttpHandler</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <RootNamespace>GSS.Authorization.OAuth2</RootNamespace>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)'=='Release' ">
-    <PackageReference Include="GSS.Authorization.OAuth2" Version="1.2.0" />
+    <PackageReference Include="GSS.Authorization.OAuth2" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GSS.Authorization.OAuth2/Authorizer.cs
+++ b/src/GSS.Authorization.OAuth2/Authorizer.cs
@@ -1,0 +1,21 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GSS.Authorization.OAuth2
+{
+    /// <summary>
+    /// Typed HttpClient to get access token
+    /// </summary>
+    public abstract class Authorizer : IAuthorizer
+    {
+        protected Authorizer(HttpClient client)
+        {
+            Client = client;
+        }
+
+        protected HttpClient Client { get; }
+
+        public abstract Task<AccessToken> GetAccessTokenAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/GSS.Authorization.OAuth2/AuthorizerHttpClient.cs
+++ b/src/GSS.Authorization.OAuth2/AuthorizerHttpClient.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Net.Http;
 
 namespace GSS.Authorization.OAuth2
@@ -5,6 +6,7 @@ namespace GSS.Authorization.OAuth2
     /// <summary>
     /// Typed HttpClient for Authenticator to grant access
     /// </summary>
+    [Obsolete("This is obsolete and will be removed in a future version.")]
     public class AuthorizerHttpClient
     {
         public AuthorizerHttpClient(HttpClient httClient)

--- a/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
+++ b/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
@@ -24,7 +24,7 @@ namespace GSS.Authorization.OAuth2
         public NetworkCredential Credentials { get; set; }
 
         /// <summary>
-        /// AuthorizerHttpClient request error handler
+        /// HttpClient request error handler
         /// </summary>
         public Action<HttpStatusCode, string> OnError { get; set; }
     }

--- a/src/GSS.Authorization.OAuth2/Authorizers/AccessTokenAuthorizerBase.cs
+++ b/src/GSS.Authorization.OAuth2/Authorizers/AccessTokenAuthorizerBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
@@ -8,11 +8,10 @@ using Newtonsoft.Json;
 
 namespace GSS.Authorization.OAuth2
 {
-    public abstract class AccessTokenAuthorizerBase : IAuthorizer
+    public abstract class AccessTokenAuthorizerBase : Authorizer
     {
-        protected AccessTokenAuthorizerBase(AuthorizerHttpClient client, IOptions<AuthorizerOptions> options)
+        protected AccessTokenAuthorizerBase(HttpClient client, IOptions<AuthorizerOptions> options) : base(client)
         {
-            Client = client;
             Options = options.Value;
             if (string.IsNullOrWhiteSpace(Options.ClientId))
             {
@@ -28,10 +27,9 @@ namespace GSS.Authorization.OAuth2
             }
         }
 
-        protected AuthorizerHttpClient Client { get; }
         protected AuthorizerOptions Options { get; }
 
-        public virtual async Task<AccessToken> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+        public override async Task<AccessToken> GetAccessTokenAsync(CancellationToken cancellationToken = default)
         {
             var formData = new Dictionary<string, string>
             {
@@ -47,7 +45,7 @@ namespace GSS.Authorization.OAuth2
             {
                 Content = new FormUrlEncodedContent(formData)
             };
-            var response = await Client.HttClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {
                 if (Options.OnError != null)

--- a/src/GSS.Authorization.OAuth2/Authorizers/ClientCredentialsAuthorizer.cs
+++ b/src/GSS.Authorization.OAuth2/Authorizers/ClientCredentialsAuthorizer.cs
@@ -1,11 +1,18 @@
+﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using Microsoft.Extensions.Options;
 
 namespace GSS.Authorization.OAuth2
 {
     public class ClientCredentialsAuthorizer : AccessTokenAuthorizerBase
     {
-        public ClientCredentialsAuthorizer(AuthorizerHttpClient client, IOptions<AuthorizerOptions> options) : base(client,options)
+        public ClientCredentialsAuthorizer(HttpClient client, IOptions<AuthorizerOptions> options) : base(client, options)
+        {
+        }
+
+        [Obsolete("This is obsolete and will be removed in a future version.")]
+        public ClientCredentialsAuthorizer(AuthorizerHttpClient client, IOptions<AuthorizerOptions> options) : base(client.HttClient,options)
         {
         }
 

--- a/src/GSS.Authorization.OAuth2/Authorizers/ResourceOwnerCredentialsAuthorizer.cs
+++ b/src/GSS.Authorization.OAuth2/Authorizers/ResourceOwnerCredentialsAuthorizer.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using Microsoft.Extensions.Options;
 
 namespace GSS.Authorization.OAuth2
@@ -7,7 +8,7 @@ namespace GSS.Authorization.OAuth2
     public class ResourceOwnerCredentialsAuthorizer : AccessTokenAuthorizerBase
     {
         public ResourceOwnerCredentialsAuthorizer(
-            AuthorizerHttpClient client,
+            HttpClient client,
             IOptions<AuthorizerOptions> options) : base(client, options)
         {
             if (options.Value.Credentials == null)
@@ -23,7 +24,14 @@ namespace GSS.Authorization.OAuth2
                 throw new ArgumentNullException(nameof(options.Value.Credentials.Password));
             }
         }
-        
+
+        [Obsolete("This is obsolete and will be removed in a future version.")]
+        public ResourceOwnerCredentialsAuthorizer(
+            AuthorizerHttpClient client,
+            IOptions<AuthorizerOptions> options) : this(client.HttClient, options)
+        {
+        }
+
         protected override void PrepareFormData(IDictionary<string, string> formData)
         {
             formData[AuthorizerDefaults.GrantType] = AuthorizerDefaults.Password;

--- a/src/GSS.Authorization.OAuth2/GSS.Authorization.OAuth2.csproj
+++ b/src/GSS.Authorization.OAuth2/GSS.Authorization.OAuth2.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>OAuth 2.0 Authorizer</Description>
     <PackageTags>OAuth;OAuth2</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -22,9 +23,9 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
         public OAuth2HttpClientTests(OAuth2Fixture fixture)
         {
             var services = fixture.BuildServiceProvider();
+            _mockHttp = services.GetService<MockHttpMessageHandler>();
             _client = services.GetRequiredService<OAuth2HttpClient>();
             _options = services.GetRequiredService<IOptions<AuthorizerOptions>>().Value;
-            _mockHttp = services.GetService<MockHttpMessageHandler>();
             _resourceEndpoint = fixture.Configuration.GetValue<Uri>("OAuth2:ResourceEndpoint");
         }
 

--- a/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
@@ -13,17 +13,17 @@ namespace GSS.Authorization.OAuth2.Tests
     public class ClientCredentialsAuthorizerTests : IClassFixture<AuthorizerFixture>
     {
         private readonly IAuthorizer _authorizer;
+        private readonly AuthorizerError _error;
         private readonly MockHttpMessageHandler _mockHttp;
         private readonly AuthorizerOptions _options;
-        private readonly AuthorizerError _error;
 
         public ClientCredentialsAuthorizerTests(AuthorizerFixture fixture)
         {
             var services = fixture.BuildServiceProvider();
-            _mockHttp = services.GetService<MockHttpMessageHandler>();
+            _authorizer = services.GetRequiredService<ClientCredentialsAuthorizer>();
             _error = services.GetRequiredService<AuthorizerError>();
+            _mockHttp = services.GetService<MockHttpMessageHandler>();
             _options = services.GetService<IOptions<AuthorizerOptions>>().Value;
-            _authorizer = ActivatorUtilities.CreateInstance<ClientCredentialsAuthorizer>(services);
         }
 
         [Fact]

--- a/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\GSS.Authorization.OAuth2.HttpClient\GSS.Authorization.OAuth2.HttpClient.csproj" />
     <ProjectReference Include="..\..\src\GSS.Authorization.OAuth2\GSS.Authorization.OAuth2.csproj" />
   </ItemGroup>
 

--- a/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\GSS.Authorization.OAuth2.HttpClient\GSS.Authorization.OAuth2.HttpClient.csproj" />
     <ProjectReference Include="..\..\src\GSS.Authorization.OAuth2\GSS.Authorization.OAuth2.csproj" />
   </ItemGroup>
 

--- a/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
@@ -13,17 +13,17 @@ namespace GSS.Authorization.OAuth2.Tests
     public class ResourceOwnerCredentialsAuthorizerTests : IClassFixture<AuthorizerFixture>
     {
         private readonly IAuthorizer _authorizer;
+        private readonly AuthorizerError _error;
         private readonly MockHttpMessageHandler _mockHttp;
         private readonly AuthorizerOptions _options;
-        private readonly AuthorizerError _error;
 
         public ResourceOwnerCredentialsAuthorizerTests(AuthorizerFixture fixture)
         {
             var services = fixture.BuildServiceProvider();
-            _mockHttp = services.GetService<MockHttpMessageHandler>();
+            _authorizer = services.GetRequiredService<ResourceOwnerCredentialsAuthorizer>();
             _error = services.GetRequiredService<AuthorizerError>();
+            _mockHttp = services.GetService<MockHttpMessageHandler>();
             _options = services.GetService<IOptions<AuthorizerOptions>>().Value;
-            _authorizer = ActivatorUtilities.CreateInstance<ResourceOwnerCredentialsAuthorizer>(services);
         }
 
         [Fact]


### PR DESCRIPTION
- Add Authorizer as abstract class of IAuthorizer to inject HttpClient
- make all authorizers as typed clients
- obsolete AuthorizerHttpClient