### PR TITLE
Avoid register duplicated OAuth2 Authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+### GSS.Authorization.OAuth2.HttpClient 1.5.1
+
+- Avoid register duplicated OAuth2 Authorizer
+- Fixes OAuth2 Authorizer type might not matched as desired
+
 ## 2019-08-10
 
 ### GSS.Authorization.OAuth2 1.5.0

--- a/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
+++ b/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-*" Condition=" '$(OS)' != 'Windows_NT' " />
   </ItemGroup>
 

--- a/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
+++ b/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Description>OAuth 2.0 authorized HttpClient, friendly with HttpClientFactory</Description>
     <PackageTags>OAuth;OAuth2;HttpClient;HttpHandler</PackageTags>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <RootNamespace>GSS.Authorization.OAuth2</RootNamespace>
   </PropertyGroup>
 

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/GSS.Authorization.OAuth2.HttpClient.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/GSS.Authorization.OAuth2.HttpClient.Tests.csproj
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net;
@@ -240,6 +240,30 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
             // Assert
             Assert.NotNull(authorizer1);
             Assert.NotNull(authorizer2);
+        }
+
+        [Fact]
+        public void AddOAuth2HttpClients_WithSameAuthorizer_ShouldNotThrows()
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            var services = collection.AddOAuth2HttpClient<ClientCredentialsAuthorizer>("client1", (resolver, options) =>
+            {
+                options.AccessTokenEndpoint = new Uri("https://example.com");
+                options.ClientId = "foo";
+                options.ClientSecret = "bar";
+            }).Services.AddOAuth2HttpClient<ClientCredentialsAuthorizer>("client2", (resolver, options) =>
+            {
+                options.AccessTokenEndpoint = new Uri("https://example.com");
+                options.ClientId = "foo";
+                options.ClientSecret = "bar";
+            }).Services.BuildServiceProvider();
+
+            // Act
+            var authorizer = services.GetService<ClientCredentialsAuthorizer>();
+
+            // Assert
+            Assert.NotNull(authorizer);
         }
     }
 }

--- a/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -18,11 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>


### PR DESCRIPTION
- Fixes OAuth2 Authorizer type might not matched as desired
- Update NuGet packages

Fixes #7 