### PR TITLE
Obsolete OAuthEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 2020-07-27
 
+### GSS.Authorization.OAuth 1.3.0
+
+- Obsolete OAuthEncoder
+
 ### GSS.Authorization.OAuth 1.2.0
 
 - Support to customize the percent encoder

--- a/src/GSS.Authorization.OAuth/GSS.Authorization.OAuth.csproj
+++ b/src/GSS.Authorization.OAuth/GSS.Authorization.OAuth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>OAuth 1.0 Authorizer and Signer</Description>
     <PackageTags>OAuth</PackageTags>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GSS.Authorization.OAuth/OAuthEncoder.cs
+++ b/src/GSS.Authorization.OAuth/OAuthEncoder.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace GSS.Authorization.OAuth
 {
+    [Obsolete("Use Uri.EscapeDataString instead")]
     public static class OAuthEncoder
     {
         private static readonly IDictionary<string, string> _uriRfc3986EscapeChars = new Dictionary<string, string>

--- a/src/GSS.Authorization.OAuth/OAuthOptions.cs
+++ b/src/GSS.Authorization.OAuth/OAuthOptions.cs
@@ -33,9 +33,23 @@ namespace GSS.Authorization.OAuth
         /// </summary>
         public string? Realm { get; set; }
 
+        [Obsolete("Use PercentEncoder instead")]
+        public Func<string?, string> PercentEncodeProvider
+        {
+            get
+            {
+                return (value) => value == null ? string.Empty : PercentEncoder(value);
+            }
+            set
+            {
+                PercentEncoder = value;
+            }
+        }
+
         /// <summary>
-        /// The Percent-Encoding Provider, see https://tools.ietf.org/html/rfc3986#section-2.1
+        /// The Percent-Encoder, see https://tools.ietf.org/html/rfc3986#section-2.1
+        /// by default, the <see cref="Uri.EscapeDataString(string)"/> is RFC3986 compliant.
         /// </summary>
-        public Func<string?, string> PercentEncodeProvider { get; set; } = OAuthEncoder.PercentEncode;
+        public Func<string, string> PercentEncoder { get; set; } = Uri.EscapeDataString;
     }
 }

--- a/src/GSS.Authorization.OAuth/RequestSignerExtensions.cs
+++ b/src/GSS.Authorization.OAuth/RequestSignerExtensions.cs
@@ -34,13 +34,13 @@ namespace GSS.Authorization.OAuth
             {
                 foreach (var value in query.GetValues(key))
                 {
-                    values.Add($"{options.PercentEncodeProvider(key)}=\"{options.PercentEncodeProvider(value)}\"");
+                    values.Add($"{options.PercentEncoder(key)}=\"{options.PercentEncoder(value)}\"");
                 }
             }
             var headerValue = string.Join(",", values);
-            if (!string.IsNullOrEmpty(options.Realm))
+            if (options.Realm != null && !string.IsNullOrWhiteSpace(options.Realm))
             {
-                return new AuthenticationHeaderValue(OAuthDefaults.OAuthScheme, $"{OAuthDefaults.Realm}=\"{options.PercentEncodeProvider(options.Realm)}\",{headerValue}");
+                return new AuthenticationHeaderValue(OAuthDefaults.OAuthScheme, $"{OAuthDefaults.Realm}=\"{options.PercentEncoder(options.Realm)}\",{headerValue}");
             }
             return new AuthenticationHeaderValue(OAuthDefaults.OAuthScheme, headerValue);
         }

--- a/src/GSS.Authorization.OAuth/Signers/HmacSha1RequestSigner.cs
+++ b/src/GSS.Authorization.OAuth/Signers/HmacSha1RequestSigner.cs
@@ -28,9 +28,13 @@ namespace GSS.Authorization.OAuth
             string consumerSecret,
             string? tokenSecret = null)
         {
-            var key = Options.PercentEncodeProvider(consumerSecret) + "&" + Options.PercentEncodeProvider(tokenSecret);
+            var key = new StringBuilder(Options.PercentEncoder(consumerSecret)).Append("&");
+            if (tokenSecret != null)
+            {
+                key.Append(Options.PercentEncoder(tokenSecret));
+            }
 #pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
-            using var hmacSha1 = new HMACSHA1(Encoding.ASCII.GetBytes(key));
+            using var hmacSha1 = new HMACSHA1(Encoding.ASCII.GetBytes(key.ToString()));
 #pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms
             var text = GetBaseString(method, uri, parameters);
             var digest = hmacSha1.ComputeHash(Encoding.ASCII.GetBytes(text));

--- a/src/GSS.Authorization.OAuth/Signers/RequestSignerBase.cs
+++ b/src/GSS.Authorization.OAuth/Signers/RequestSignerBase.cs
@@ -51,7 +51,7 @@ namespace GSS.Authorization.OAuth
             {
                 foreach (var value in parameters.GetValues(key))
                 {
-                    normalizationParameters.Add(new KeyValuePair<string, string>(Options.PercentEncodeProvider(key), Options.PercentEncodeProvider(value)));
+                    normalizationParameters.Add(new KeyValuePair<string, string>(Options.PercentEncoder(key), Options.PercentEncoder(value)));
                 }
             }
             var values = normalizationParameters
@@ -61,8 +61,8 @@ namespace GSS.Authorization.OAuth
             var parts = new List<string>
             {
                 method.Method.ToUpperInvariant(),
-                Options.PercentEncodeProvider(baseUri),
-                Options.PercentEncodeProvider(string.Join("&", values))
+                Options.PercentEncoder(baseUri),
+                Options.PercentEncoder(string.Join("&", values))
             };
             return string.Join("&", parts);
         }


### PR DESCRIPTION
- The [Uri.EscapeDataString](https://docs.microsoft.com/dotnet/api/system.uri.escapedatastring) is RFC-3986 compliant
- Renamed PercentEncodeProvider to PercentEncoder