### PR TITLE
Update to .NET 6.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.8.13",
+      "version": "5.0.0",
       "commands": [
         "reportgenerator"
       ]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Build packages
         run: |
           dotnet --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      - name: Set up .NET 5 SDK
+      - name: Set up .NET 6 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Build
         run: |
           dotnet --info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.3.1 (2021-11-14)
+
+- Floating latest dependencies for .NET 6
+- [RNGCryptoServiceProvider is obsolete since .NET 6](https://github.com/dotnet/runtime/issues/40169)
+- Bump System.ComponentModel.Annotations from 4.5.0 to 4.7.0
+
 ## 2.3.0 (2021-06-11)
 
 - Floating latest dependencies for .NET Core 3.1 and .NET 5

--- a/OAuth.sln
+++ b/OAuth.sln
@@ -35,6 +35,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GSS.Authorization.OAuth2.HttpClient.Tests", "test\GSS.Authorization.OAuth2.HttpClient.Tests\GSS.Authorization.OAuth2.HttpClient.Tests.csproj", "{28080D26-3251-4619-AD9D-54381759ED2A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{F0FA418E-E9E8-4A7F-835D-A00476B78754}"
+ProjectSection(SolutionItems) = preProject
+	samples\Directory.Build.props = samples\Directory.Build.props
+EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OAuth2HttpClientSample", "samples\OAuth2HttpClientSample\OAuth2HttpClientSample.csproj", "{D67C5C98-4344-4E1F-B809-5A91551C90EC}"
 EndProject

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
+++ b/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
+++ b/samples/OAuth2HttpClientSample/OAuth2HttpClientSample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/OAuth2HttpClientSample/Program.cs
+++ b/samples/OAuth2HttpClientSample/Program.cs
@@ -1,60 +1,45 @@
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using GSS.Authorization.OAuth2;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace OAuth2HttpClientSample
+static void ConfigureAuthorizerOptions(IServiceProvider resolver, AuthorizerOptions options)
 {
-    public class Program
-    {
-        public static async Task Main(string[] args)
-        {
-            var host = Host.CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) =>
-                {
-                    var clientBuilder =
-                        hostContext.Configuration.GetValue("OAuth2:GrantFlow", "ClientCredentials")
-                            .Equals("ClientCredentials", StringComparison.OrdinalIgnoreCase)
-                            ? services.AddOAuth2HttpClient<OAuth2HttpClient, ClientCredentialsAuthorizer>(
-                                ConfigureAuthorizerOptions)
-                            : services.AddOAuth2HttpClient<OAuth2HttpClient, ResourceOwnerCredentialsAuthorizer>(
-                                ConfigureAuthorizerOptions);
-                    clientBuilder.ConfigureHttpClient(client =>
-                    {
-                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    });
-                }).Build();
-            var configuration = host.Services.GetRequiredService<IConfiguration>();
-
-            Console.WriteLine("Creating a client...");
-            var oauth2Client = host.Services.GetRequiredService<OAuth2HttpClient>();
-
-            Console.WriteLine("Sending a request...");
-            var response = await oauth2Client.HttpClient.GetAsync(configuration.GetValue<Uri>("OAuth2:ResourceEndpoint")).ConfigureAwait(false);
-            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Console.WriteLine("Response data:");
-            Console.WriteLine(data);
-        }
-
-        private static void ConfigureAuthorizerOptions(IServiceProvider resolver, AuthorizerOptions options)
-        {
-            var configuration = resolver.GetRequiredService<IConfiguration>();
-            options.AccessTokenEndpoint = configuration.GetValue<Uri>("OAuth2:AccessTokenEndpoint");
-            options.ClientId = configuration["OAuth2:ClientId"];
-            options.ClientSecret = configuration["OAuth2:ClientSecret"];
-            options.Credentials = new NetworkCredential(
-                configuration["OAuth2:Credentials:UserName"],
-                configuration["OAuth2:Credentials:Password"]);
-            options.Scopes = configuration.GetSection("OAuth2:Scopes").Get<IEnumerable<string>>();
-            options.OnError = (code, message) =>
-            {
-                Console.Error.Write($"ERROR: [${code}]: {message}");
-            };
-        }
-    }
+    var configuration = resolver.GetRequiredService<IConfiguration>();
+    options.AccessTokenEndpoint = configuration.GetValue<Uri>("OAuth2:AccessTokenEndpoint");
+    options.ClientId = configuration["OAuth2:ClientId"];
+    options.ClientSecret = configuration["OAuth2:ClientSecret"];
+    options.Credentials = new NetworkCredential(
+        configuration["OAuth2:Credentials:UserName"],
+        configuration["OAuth2:Credentials:Password"]);
+    options.Scopes = configuration.GetSection("OAuth2:Scopes").Get<IEnumerable<string>>();
+    options.OnError = (code, message) => Console.Error.Write($"ERROR: [${code}]: {message}");
 }
+
+var host = Host.CreateDefaultBuilder(args)
+.ConfigureServices((hostContext, services) =>
+{
+    var clientBuilder =
+        hostContext.Configuration.GetValue("OAuth2:GrantFlow", "ClientCredentials")
+            .Equals("ClientCredentials", StringComparison.OrdinalIgnoreCase)
+            ? services.AddOAuth2HttpClient<OAuth2HttpClient, ClientCredentialsAuthorizer>(
+                ConfigureAuthorizerOptions)
+            : services.AddOAuth2HttpClient<OAuth2HttpClient, ResourceOwnerCredentialsAuthorizer>(
+                ConfigureAuthorizerOptions);
+    clientBuilder.ConfigureHttpClient(client => client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json")));
+}).Build();
+var configuration = host.Services.GetRequiredService<IConfiguration>();
+
+Console.WriteLine("Creating a client...");
+var oauth2Client = host.Services.GetRequiredService<OAuth2HttpClient>();
+
+Console.WriteLine("Sending a request...");
+var response = await oauth2Client.HttpClient.GetAsync(configuration.GetValue<Uri>("OAuth2:ResourceEndpoint")).ConfigureAwait(false);
+
+Console.WriteLine("Response data:");
+var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+Console.WriteLine(data);
+
+

--- a/samples/OAuth2HttpClientSample/appsettings.json
+++ b/samples/OAuth2HttpClientSample/appsettings.json
@@ -1,14 +1,11 @@
 {
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information"
     }
   },
   "OAuth2": {
-    "AccessTokenEndpoint": "https://example.com/oauth2/accessToken",
+    "AccessTokenEndpoint": "https://example.com/oauth2/token",
     "ResourceEndpoint": "https://example.com/oauth2/profile",
     "ClientId": "CHANGE_ME",
     "ClientSecret": "CHANGE_ME",

--- a/samples/OAuthHttpClientSample/OAuthHttpClientSample.csproj
+++ b/samples/OAuthHttpClientSample/OAuthHttpClientSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/OAuthHttpClientSample/OAuthHttpClientSample.csproj
+++ b/samples/OAuthHttpClientSample/OAuthHttpClientSample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   
   <ItemGroup>

--- a/samples/OAuthHttpClientSample/Program.cs
+++ b/samples/OAuthHttpClientSample/Program.cs
@@ -1,54 +1,40 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using GSS.Authorization.OAuth;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace OAuthHttpClientSample
+var host = Host.CreateDefaultBuilder(args)
+.ConfigureServices((hostContext, services) =>
 {
-    public static class Program
+    services.AddOAuthHttpClient<OAuthHttpClient>((_, options) =>
     {
-        public static async Task Main(string[] args)
-        {
-            var host = Host.CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddOAuthHttpClient<OAuthHttpClient>((_, options) =>
-                   {
-                       options.ClientCredentials = new OAuthCredential(
-                           hostContext.Configuration["OAuth:ClientId"],
-                           hostContext.Configuration["OAuth:ClientSecret"]);
-                       options.TokenCredentials = new OAuthCredential(
-                               hostContext.Configuration["OAuth:TokenId"],
-                               hostContext.Configuration["OAuth:TokenSecret"]);
-                       options.SignedAsQuery = hostContext.Configuration.GetValue("OAuth:SignedAsQuery", false);
-                       options.SignedAsBody = hostContext.Configuration.GetValue("OAuth:SignedAsBody", false);
-                   }).ConfigureHttpClient(client =>
-                   {
-                       client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                   });
-                }).Build();
-            var configuration = host.Services.GetRequiredService<IConfiguration>();
+        options.ClientCredentials = new OAuthCredential(
+            hostContext.Configuration["OAuth:ClientId"],
+            hostContext.Configuration["OAuth:ClientSecret"]);
+        options.TokenCredentials = new OAuthCredential(
+                hostContext.Configuration["OAuth:TokenId"],
+                hostContext.Configuration["OAuth:TokenSecret"]);
+        options.SignedAsQuery = hostContext.Configuration.GetValue("OAuth:SignedAsQuery", false);
+        options.SignedAsBody = hostContext.Configuration.GetValue("OAuth:SignedAsBody", false);
+    }).ConfigureHttpClient(client => client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json")));
+}).Build();
 
-            Console.WriteLine("Creating a client...");
-            var oauthClient = host.Services.GetRequiredService<OAuthHttpClient>();
+var configuration = host.Services.GetRequiredService<IConfiguration>();
 
-            Console.WriteLine("Sending a request...");
-            var method = new HttpMethod(configuration.GetValue("Request:Method", HttpMethod.Get.Method));
-            var request = new HttpRequestMessage(method, configuration.GetValue<Uri>("Request:Uri"));
-            var body = configuration.GetSection("Request:Body").Get<IDictionary<string, string>>();
-            if (body != null)
-            {
-                request.Content = new FormUrlEncodedContent(body);
-            }
-            var response = await oauthClient.HttpClient.SendAsync(request).ConfigureAwait(false);
-            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            Console.WriteLine("Response data:");
-            Console.WriteLine(data);
-        }
-    }
+Console.WriteLine("Creating a client...");
+var oauthClient = host.Services.GetRequiredService<OAuthHttpClient>();
+
+Console.WriteLine("Sending a request...");
+var method = new HttpMethod(configuration.GetValue("Request:Method", HttpMethod.Get.Method));
+var request = new HttpRequestMessage(method, configuration.GetValue<Uri>("Request:Uri"));
+var body = configuration.GetSection("Request:Body").Get<IDictionary<string, string>>();
+if (body != null)
+{
+    request.Content = new FormUrlEncodedContent(body);
 }
+var response = await oauthClient.HttpClient.SendAsync(request).ConfigureAwait(false);
+
+Console.WriteLine("Response data:");
+var data = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+Console.WriteLine(data);

--- a/samples/OAuthHttpClientSample/appsettings.json
+++ b/samples/OAuthHttpClientSample/appsettings.json
@@ -1,10 +1,7 @@
 {
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information"
     }
   },
   "OAuth": {
@@ -14,7 +11,7 @@
     "TokenSecret": "CHANGE_ME"
   },
   "Request": {
-    "Uri": "https://example.com/oauth/profile",
-    "Method": "GET"
+    "Method": "GET",
+    "Uri": "https://example.com/oauth/profile"
   }
 }

--- a/samples/OAuthInteractiveConsoleAuthorizer/OAuthInteractiveConsoleAuthorizer.csproj
+++ b/samples/OAuthInteractiveConsoleAuthorizer/OAuthInteractiveConsoleAuthorizer.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -27,7 +27,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/OAuthInteractiveConsoleAuthorizer/OAuthInteractiveConsoleAuthorizer.csproj
+++ b/samples/OAuthInteractiveConsoleAuthorizer/OAuthInteractiveConsoleAuthorizer.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>

--- a/samples/OAuthInteractiveConsoleAuthorizer/Program.cs
+++ b/samples/OAuthInteractiveConsoleAuthorizer/Program.cs
@@ -1,72 +1,34 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 using GSS.Authorization.OAuth;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace OAuthInteractiveConsoleGrantTool
+var host = Host.CreateDefaultBuilder()
+.ConfigureServices((context, services) =>
 {
-    public class Program
-    {
-        private readonly IAuthorizer _authorizer;
-
-        public Program(IAuthorizer authorizer)
+    services.AddOptions<AuthorizerOptions>()
+        .Configure(options =>
         {
-            _authorizer = authorizer;
-        }
+            options.ClientCredentials = new OAuthCredential(
+                context.Configuration["OAuth:ClientId"],
+                context.Configuration["OAuth:ClientSecret"]);
+            options.CallBack = context.Configuration.GetValue<Uri>("OAuth:Callback");
+            options.TemporaryCredentialRequestUri = context.Configuration.GetValue<Uri>("OAuth:TemporaryCredentialRequestUri");
+            options.ResourceOwnerAuthorizeUri = context.Configuration.GetValue<Uri>("OAuth:ResourceOwnerAuthorizeUri");
+            options.TokenRequestUri = context.Configuration.GetValue<Uri>("OAuth:TokenRequestUri");
+        })
+        .PostConfigure(options => Validator.ValidateObject(options, new ValidationContext(options), true));
+    services.AddSingleton<IRequestSigner, HmacSha1RequestSigner>();
+    services.AddHttpClient<InteractiveConsoleAuthorizer>()
+        .ConfigureHttpClient(client => client.BaseAddress = context.Configuration.GetValue<Uri>("OAuth:BaseAddress"));
+    services.AddTransient<IAuthorizer>(resolver => resolver.GetRequiredService<InteractiveConsoleAuthorizer>());
+}).Build();
 
-        public static async Task<int> Main(string[] args)
-        {
-            var mainModule = Process.GetCurrentProcess().MainModule;
-            var hostBuilder = Host.CreateDefaultBuilder();
-            if (mainModule != null)
-            {
-                hostBuilder.ConfigureAppConfiguration(config =>
-                {
-                    config.SetBasePath(Path.GetDirectoryName(mainModule.FileName));
-                });
-            }
-            return await hostBuilder.ConfigureServices((context, services) =>
-                {
-                    services.AddOptions<AuthorizerOptions>()
-                        .Configure(options =>
-                        {
-                            options.ClientCredentials = new OAuthCredential(
-                                context.Configuration["OAuth:ClientId"],
-                                context.Configuration["OAuth:ClientSecret"]);
-                            options.CallBack = context.Configuration.GetValue<Uri>("OAuth:Callback");
-                            options.TemporaryCredentialRequestUri = context.Configuration.GetValue<Uri>("OAuth:TemporaryCredentialRequestUri");
-                            options.ResourceOwnerAuthorizeUri = context.Configuration.GetValue<Uri>("OAuth:ResourceOwnerAuthorizeUri");
-                            options.TokenRequestUri = context.Configuration.GetValue<Uri>("OAuth:TokenRequestUri");
-                        })
-                        .PostConfigure(options =>
-                        {
-                            Validator.ValidateObject(options, new ValidationContext(options), true);
-                        });
-                    services.AddSingleton<IRequestSigner, HmacSha1RequestSigner>();
-                    services.AddHttpClient<InteractiveConsoleAuthorizer>()
-                        .ConfigureHttpClient(client =>
-                        {
-                            client.BaseAddress = context.Configuration.GetValue<Uri>("OAuth:BaseAddress");
-                        });
-                    services.AddTransient<IAuthorizer>(resolver => resolver.GetRequiredService<InteractiveConsoleAuthorizer>());
-                })
-                .RunCommandLineApplicationAsync<Program>(args).ConfigureAwait(false);
-        }
-
-        private async Task OnExecuteAsync(CancellationToken cancellationToken = default)
-        {
-            var tokenCredentials = await _authorizer.GrantAccessAsync(cancellationToken).ConfigureAwait(false);
-            Console.WriteLine("Token Credentials ...");
-            Console.WriteLine($"Key: {tokenCredentials.Key}");
-            Console.WriteLine($"Secret: {tokenCredentials.Secret}");
-            Console.WriteLine("Press any key to exit...");
-            Console.ReadKey();
-        }
-    }
-}
+var authorizer = host.Services.GetRequiredService<IAuthorizer>();
+var tokenCredentials = await authorizer.GrantAccessAsync().ConfigureAwait(false);
+Console.WriteLine("Token Credentials ...");
+Console.WriteLine($"Key: {tokenCredentials.Key}");
+Console.WriteLine($"Secret: {tokenCredentials.Secret}");
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();

--- a/samples/OAuthInteractiveConsoleAuthorizer/appsettings.json
+++ b/samples/OAuthInteractiveConsoleAuthorizer/appsettings.json
@@ -1,10 +1,7 @@
 {
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Information",
-      "System": "Warning",
-      "Microsoft": "Warning"
+      "Default": "Information"
     }
   },
   "OAuth": {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
     <Version>2.3.0</Version>
   </PropertyGroup>
@@ -23,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authorization.OAuth.HttpClient/GSS.Authorization.OAuth.HttpClient.csproj
+++ b/src/GSS.Authorization.OAuth.HttpClient/GSS.Authorization.OAuth.HttpClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>OAuth 1.0 authorized HttpClient, friendly with HttpClientFactory</Description>
     <PackageTags>OAuth;HttpClient;HttpHandler</PackageTags>
     <RootNamespace>GSS.Authorization.OAuth</RootNamespace>
@@ -25,6 +25,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.*" />
   </ItemGroup>
 
 </Project>

--- a/src/GSS.Authorization.OAuth/InteractiveConsoleAuthorizer.cs
+++ b/src/GSS.Authorization.OAuth/InteractiveConsoleAuthorizer.cs
@@ -39,16 +39,9 @@ namespace GSS.Authorization.OAuth
                     UseShellExecute = true
                 });
             }
-            catch
+            catch when (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    Process.Start("xdg-open", uri.AbsoluteUri);
-                }
-                else
-                {
-                    throw;
-                }
+                Process.Start("xdg-open", uri.AbsoluteUri);
             }
         }
     }

--- a/src/GSS.Authorization.OAuth/OAuthOptions.cs
+++ b/src/GSS.Authorization.OAuth/OAuthOptions.cs
@@ -7,7 +7,7 @@ namespace GSS.Authorization.OAuth
 {
     public class OAuthOptions
     {
-        private static readonly RNGCryptoServiceProvider _rngCrypto = new RNGCryptoServiceProvider();
+        private static readonly RandomNumberGenerator _randomNumberGenerator = RandomNumberGenerator.Create();
 
         [Required]
         public OAuthCredential ClientCredentials { get; set; }
@@ -16,7 +16,7 @@ namespace GSS.Authorization.OAuth
         public Func<string> NonceProvider { get; set; } = () =>
         {
             var bytes = new byte[16];
-            _rngCrypto.GetNonZeroBytes(bytes);
+            _randomNumberGenerator.GetNonZeroBytes(bytes);
             return Convert.ToBase64String(bytes);
         };
 

--- a/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
+++ b/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>OAuth 2.0 authorized HttpClient, friendly with HttpClientFactory</Description>
     <PackageTags>OAuth;OAuth2;HttpClient;HttpHandler</PackageTags>
     <RootNamespace>GSS.Authorization.OAuth2</RootNamespace>
@@ -28,6 +28,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.*" />
   </ItemGroup>
 
 </Project>

--- a/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandler.cs
+++ b/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandler.cs
@@ -11,7 +11,7 @@ namespace GSS.Authorization.OAuth2
 {
     public class OAuth2HttpHandler : DelegatingHandler
     {
-        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly IAuthorizer _authorizer;
         private readonly IMemoryCache _memoryCache;
         private readonly string _cacheKey;

--- a/src/GSS.Authorization.OAuth2/AccessToken.cs
+++ b/src/GSS.Authorization.OAuth2/AccessToken.cs
@@ -5,7 +5,7 @@ namespace GSS.Authorization.OAuth2
 {
     public class AccessToken
     {
-        public static readonly AccessToken Empty = new AccessToken();
+        public static readonly AccessToken Empty = new();
 
         [JsonPropertyName("access_token")]
         public string Token { get; set; } = default!;

--- a/src/GSS.Authorization.OAuth2/GSS.Authorization.OAuth2.csproj
+++ b/src/GSS.Authorization.OAuth2/GSS.Authorization.OAuth2.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/GSS.Authorization.OAuth.HttpClient.Tests/GSS.Authorization.OAuth.HttpClient.Tests.csproj
+++ b/test/GSS.Authorization.OAuth.HttpClient.Tests/GSS.Authorization.OAuth.HttpClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GSS.Authorization.OAuth.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/GSS.Authorization.OAuth.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
@@ -17,7 +15,9 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             var collection = new ServiceCollection();
 
             // Act & Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => collection.AddOAuthHttpClient<OAuthHttpClient>(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]
@@ -53,10 +53,9 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
         {
             // Arrange
             var collection = new ServiceCollection();
-            var services = collection.AddOAuthHttpClient<OAuthHttpClient>((_, options) =>
-            {
-                options.ClientCredentials = new OAuthCredential("foo", null);
-            }).Services.BuildServiceProvider();
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            var services = collection.AddOAuthHttpClient<OAuthHttpClient>((_, options) => options.ClientCredentials = new OAuthCredential("foo", null)).Services.BuildServiceProvider();
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             // Act
             var ex = Assert.Throws<ArgumentNullException>(() => services.GetRequiredService<IOptions<OAuthHttpHandlerOptions>>().Value);
@@ -73,7 +72,9 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             var services = collection.AddOAuthHttpClient<OAuthHttpClient>((_, options) =>
             {
                 options.ClientCredentials = new OAuthCredential("foo", "bar");
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 options.TokenCredentials = new OAuthCredential(null, "bar");
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
             }).Services.BuildServiceProvider();
 
             // Act
@@ -91,7 +92,9 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             var services = collection.AddOAuthHttpClient<OAuthHttpClient>((_, options) =>
             {
                 options.ClientCredentials = new OAuthCredential("foo", "bar");
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 options.TokenCredentials = new OAuthCredential("foo", null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
             }).Services.BuildServiceProvider();
 
             // Act
@@ -136,10 +139,10 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             // Assert
             Assert.NotNull(client);
         }
-        
+
         [Fact]
         public void AddOAuthHttpClient_WithGenericConfigurePrimaryHttpMessageHandler_ShouldAddInHttpMessageHandlerBuilderActions()
-        {   
+        {
             // Arrange
             var mockHttp = new MockHttpMessageHandler();
             var collection = new ServiceCollection();
@@ -151,10 +154,10 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
                     options.TokenCredentials = new OAuthCredential("foo", "bar");
                 }).ConfigurePrimaryHttpMessageHandler<MockHttpMessageHandler>();
             var services = builder.Services.BuildServiceProvider();
-            
+
             // Act
             var optionsMonitor = services.GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>();
-            
+
             // Assert
             var httpClientFactoryOptions = optionsMonitor.Get(builder.Name);
             Assert.Contains(httpClientFactoryOptions.HttpMessageHandlerBuilderActions, x => x.Target?.ToString()?.Contains("MockHttpMessageHandler") == true);
@@ -212,7 +215,7 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
 
         private class DemoOptions : OAuthHttpHandlerOptions
         {
-            public Uri BaseAddress { get; set; }
+            public Uri BaseAddress { get; set; } = default!;
         }
 
         [Fact]

--- a/test/GSS.Authorization.OAuth.HttpClient.Tests/appsettings.json
+++ b/test/GSS.Authorization.OAuth.HttpClient.Tests/appsettings.json
@@ -3,11 +3,8 @@
     "Mock": true
   },
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information"
     }
   },
   "OAuth": {

--- a/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -14,7 +10,7 @@ namespace GSS.Authorization.OAuth.Tests
     // see https://tools.ietf.org/html/rfc5849#section-1.2
     public class AuthorizerTests
     {
-        private readonly AuthorizerOptions _options = new AuthorizerOptions
+        private readonly AuthorizerOptions _options = new()
         {
             ClientCredentials = new OAuthCredential("dpf43f3p2l4k3l03", "kd94hf93k423kf44"),
             TemporaryCredentialRequestUri = new Uri("https://photos.example.net/initiate"),
@@ -25,7 +21,7 @@ namespace GSS.Authorization.OAuth.Tests
             ProvideVersion = false
         };
 
-        private readonly MockHttpMessageHandler _mockHttp = new MockHttpMessageHandler();
+        private readonly MockHttpMessageHandler _mockHttp = new();
         private readonly IRequestSigner _signer = new HmacSha1RequestSigner();
 
         [Fact]
@@ -67,7 +63,7 @@ namespace GSS.Authorization.OAuth.Tests
         public async Task GetVerificationCodeAsync()
         {
             // Arrange
-            var expected = "hfdp7dh39dks9884";
+            const string expected = "hfdp7dh39dks9884";
             var authorizeHtml = $@"<form action='{_options.ResourceOwnerAuthorizeUri}' method='post'>
 <input type='text' name='uid'>
 <input type='password' name='pwd'>
@@ -95,7 +91,7 @@ namespace GSS.Authorization.OAuth.Tests
         {
             // Arrange
             var expected = new OAuthCredential("nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
-            var verificationCode = "hfdp7dh39dks9884";
+            const string verificationCode = "hfdp7dh39dks9884";
             _options.NonceProvider = () => "walatlh";
             _options.TimestampProvider = () => "137131201";
             var temporaryCredential = new OAuthCredential("hh5s93j4hdidpola", "hdhd0244k9j7ao03");
@@ -133,7 +129,7 @@ namespace GSS.Authorization.OAuth.Tests
             // Arrange
             var expected = new OAuthCredential("nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
             var temporaryCredentials = new OAuthCredential("hh5s93j4hdidpola", "hdhd0244k9j7ao03");
-            var verificationCode = "hfdp7dh39dks9884";
+            const string verificationCode = "hfdp7dh39dks9884";
             _options.NonceProvider = () => "walatlh";
             _options.TimestampProvider = () => "137131201";
             _mockHttp.When(HttpMethod.Post, _options.TemporaryCredentialRequestUri.ToString())

--- a/test/GSS.Authorization.OAuth.Tests/FakeAuthorizer.cs
+++ b/test/GSS.Authorization.OAuth.Tests/FakeAuthorizer.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 
 namespace GSS.Authorization.OAuth.Tests
@@ -13,7 +9,7 @@ namespace GSS.Authorization.OAuth.Tests
         {
         }
 
-        public string VerificationCode { get; set; }
+        public string VerificationCode { get; set; } = default!;
 
         public override Task<string> GetVerificationCodeAsync(Uri authorizeUri,
             CancellationToken cancellationToken = default)

--- a/test/GSS.Authorization.OAuth.Tests/GSS.Authorization.OAuth.Tests.csproj
+++ b/test/GSS.Authorization.OAuth.Tests/GSS.Authorization.OAuth.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GSS.Authorization.OAuth.Tests/RequestSignerTests.cs
+++ b/test/GSS.Authorization.OAuth.Tests/RequestSignerTests.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Primitives;
 using Xunit;
@@ -29,7 +26,7 @@ namespace GSS.Authorization.OAuth.Tests
                 [OAuthDefaults.OAuthNonce] = "7d8f3e4a",
                 ["c2"] = ""
             };
-            var expected =
+            const string expected =
                 "POST&http%3A%2F%2Fexample.com%2Frequest&a2%3Dr%2520b%26a3%3D2%2520q%26a3%3Da%26b5%3D%253D%25253D%26c%2540%3D%26c2%3D%26oauth_consumer_key%3D9djdj82h48djs9d2%26oauth_nonce%3D7d8f3e4a%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D137131201%26oauth_token%3Dkkk9d7dh3k39sjv7";
 
             // Act
@@ -44,7 +41,7 @@ namespace GSS.Authorization.OAuth.Tests
         public void GetSignatureForTemporaryCredentials()
         {
             // Arrange
-            var expected = "74KNZJeDHnMBp0EMJ9ZHt/XKycU=";
+            const string expected = "74KNZJeDHnMBp0EMJ9ZHt/XKycU=";
             var clientCredentials = new OAuthCredential("dpf43f3p2l4k3l03", "kd94hf93k423kf44");
             var uri = new Uri("https://photos.example.net/initiate");
             var parameters = new Dictionary<string, StringValues>
@@ -70,7 +67,7 @@ namespace GSS.Authorization.OAuth.Tests
         public void GetSignatureForTokenCredentials()
         {
             // Arrange
-            var expected = "gKgrFCywp7rO0OXSjdot/IHF7IU=";
+            const string expected = "gKgrFCywp7rO0OXSjdot/IHF7IU=";
             var clientCredentials = new OAuthCredential("dpf43f3p2l4k3l03", "kd94hf93k423kf44");
             var temporaryCredentials = new OAuthCredential("hh5s93j4hdidpola", "hdhd0244k9j7ao03");
             var uri = new Uri("https://photos.example.net/token");
@@ -98,7 +95,7 @@ namespace GSS.Authorization.OAuth.Tests
         public void GetSignatureForResource()
         {
             // Arrange
-            var expected = "MdpQcU8iPSUjWoN/UDMsK2sui9I=";
+            const string expected = "MdpQcU8iPSUjWoN/UDMsK2sui9I=";
             var clientCredentials = new OAuthCredential("dpf43f3p2l4k3l03", "kd94hf93k423kf44");
             var tokenCredentials = new OAuthCredential("nnch734d00sl2jdk", "pfkkdhi9sl3r4s00");
             var uri = new Uri("http://photos.example.net/photos?file=vacation.jpg&size=original");

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/GSS.Authorization.OAuth2.HttpClient.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/GSS.Authorization.OAuth2.HttpClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2Fixture.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2Fixture.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,7 +16,7 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
 
         public IConfiguration Configuration { get; }
 
-        public IServiceProvider BuildOAuth2HttpClient(HttpMessageHandler handler)
+        public IServiceProvider BuildOAuth2HttpClient(HttpMessageHandler? handler)
         {
             handler ??= new HttpClientHandler();
             var services = new ServiceCollection();

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +12,7 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
     public class OAuth2HttpClientTests : IClassFixture<OAuth2Fixture>
     {
         private readonly OAuth2HttpClient _client;
-        private readonly MockHttpMessageHandler _mockHttp;
+        private readonly MockHttpMessageHandler? _mockHttp;
         private readonly Uri _resourceEndpoint;
         private readonly AuthorizerOptions _options;
 

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,8 +1,5 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Options;
@@ -20,7 +17,9 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
             var collection = new ServiceCollection();
 
             // Act & Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             Assert.Throws<ArgumentNullException>(() => collection.AddOAuth2HttpClient<OAuth2HttpClient, ClientCredentialsAuthorizer>(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         }
 
         [Fact]
@@ -105,10 +104,10 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
             // Assert
             Assert.NotNull(authorizerOptions);
         }
-        
+
         [Fact]
         public void AddOAuth2HttpClient_WithGenericConfigurePrimaryHttpMessageHandler_ShouldAddInHttpMessageHandlerBuilderActions()
-        {   
+        {
             // Arrange
             var mockHttp = new MockHttpMessageHandler();
             var collection = new ServiceCollection();
@@ -121,10 +120,10 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
                     options.ClientSecret = "bar";
                 }).ConfigurePrimaryHttpMessageHandler<MockHttpMessageHandler>();
             var services = builder.Services.BuildServiceProvider();
-            
+
             // Act
             var optionsMonitor = services.GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>();
-            
+
             // Assert
             var httpClientFactoryOptions = optionsMonitor.Get(builder.Name);
             Assert.Contains(httpClientFactoryOptions.HttpMessageHandlerBuilderActions, x => x.Target?.ToString()?.Contains("MockHttpMessageHandler") == true);

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/appsettings.json
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/appsettings.json
@@ -3,11 +3,8 @@
     "Mock": true
   },
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information"
     }
   },
   "OAuth2": {

--- a/test/GSS.Authorization.OAuth2.Tests/AuthorizerFixture.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/AuthorizerFixture.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
-using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,7 +16,7 @@ namespace GSS.Authorization.OAuth2.Tests
 
         public IConfiguration Configuration { get; }
 
-        public IServiceProvider BuildAuthorizer<TAuthorizer>(HttpMessageHandler handler, Action<HttpStatusCode, string> errorHandler)
+        public IServiceProvider BuildAuthorizer<TAuthorizer>(HttpMessageHandler? handler, Action<HttpStatusCode, string>? errorHandler)
             where TAuthorizer : class
         {
             handler ??= new HttpClientHandler();

--- a/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,10 +11,10 @@ namespace GSS.Authorization.OAuth2.Tests
     public class ClientCredentialsAuthorizerTests : IClassFixture<AuthorizerFixture>
     {
         private readonly IAuthorizer _authorizer;
-        private readonly MockHttpMessageHandler _mockHttp;
+        private readonly MockHttpMessageHandler? _mockHttp;
         private readonly AuthorizerOptions _options;
         private HttpStatusCode _errorStatusCode;
-        private string _errorMessage;
+        private string? _errorMessage;
 
         public ClientCredentialsAuthorizerTests(AuthorizerFixture fixture)
         {

--- a/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
+++ b/test/GSS.Authorization.OAuth2.Tests/GSS.Authorization.OAuth2.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,10 +11,10 @@ namespace GSS.Authorization.OAuth2.Tests
     public class ResourceOwnerCredentialsAuthorizerTests : IClassFixture<AuthorizerFixture>
     {
         private readonly IAuthorizer _authorizer;
-        private readonly MockHttpMessageHandler _mockHttp;
+        private readonly MockHttpMessageHandler? _mockHttp;
         private readonly AuthorizerOptions _options;
         private HttpStatusCode _errorStatusCode;
-        private string _errorMessage;
+        private string? _errorMessage;
 
         public ResourceOwnerCredentialsAuthorizerTests(AuthorizerFixture fixture)
         {
@@ -42,8 +39,8 @@ namespace GSS.Authorization.OAuth2.Tests
                 .WithFormData(AuthorizerDefaults.ClientId, _options.ClientId)
                 .WithFormData(AuthorizerDefaults.ClientSecret, _options.ClientSecret)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
-                .WithFormData(AuthorizerDefaults.Username, _options.Credentials.UserName)
-                .WithFormData(AuthorizerDefaults.Password, _options.Credentials.Password)
+                .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
+                .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
                 .Respond("application/json", JsonSerializer.Serialize(new AccessToken
                 {
                     Token = Guid.NewGuid().ToString(),
@@ -66,8 +63,8 @@ namespace GSS.Authorization.OAuth2.Tests
                 .WithFormData(AuthorizerDefaults.ClientId, _options.ClientId)
                 .WithFormData(AuthorizerDefaults.ClientSecret, _options.ClientSecret)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
-                .WithFormData(AuthorizerDefaults.Username, _options.Credentials.UserName)
-                .WithFormData(AuthorizerDefaults.Password, _options.Credentials.Password)
+                .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
+                .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
                 .Respond("application/json", JsonSerializer.Serialize(new AccessToken
                 {
                     Token = Guid.NewGuid().ToString(),
@@ -92,8 +89,8 @@ namespace GSS.Authorization.OAuth2.Tests
                 .WithFormData(AuthorizerDefaults.ClientId, _options.ClientId)
                 .WithFormData(AuthorizerDefaults.ClientSecret, _options.ClientSecret)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
-                .WithFormData(AuthorizerDefaults.Username, _options.Credentials.UserName)
-                .WithFormData(AuthorizerDefaults.Password, _options.Credentials.Password)
+                .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
+                .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
                 .Respond(HttpStatusCode.InternalServerError);
 
             // Act
@@ -115,8 +112,8 @@ namespace GSS.Authorization.OAuth2.Tests
                 .WithFormData(AuthorizerDefaults.ClientId, _options.ClientId)
                 .WithFormData(AuthorizerDefaults.ClientSecret, _options.ClientSecret)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
-                .WithFormData(AuthorizerDefaults.Username, _options.Credentials.UserName)
-                .WithFormData(AuthorizerDefaults.Password, _options.Credentials.Password)
+                .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
+                .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
                 .Respond(HttpStatusCode.InternalServerError, "application/json", expectedErrorMessage);
 
             // Act

--- a/test/GSS.Authorization.OAuth2.Tests/appsettings.json
+++ b/test/GSS.Authorization.OAuth2.Tests/appsettings.json
@@ -3,15 +3,12 @@
     "Mock": true
   },
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information"
     }
   },
   "OAuth2": {
-    "AccessTokenEndpoint": "https://example.com/oauth2/accessToken",
+    "AccessTokenEndpoint": "https://example.com/oauth2/token",
     "ClientId": "CHANGE_ME",
     "ClientSecret": "CHANGE_ME",
     "Credentials": {


### PR DESCRIPTION
- [Prefer to use .NET SDK built-in analyzers](https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisnetanalyzers)
- [Migrate to Minimal APIs](https://docs.microsoft.com/aspnet/core/fundamentals/minimal-apis)
- [RNGCryptoServiceProvider is obsolete since .NET 6](https://github.com/dotnet/runtime/issues/40169)
- Floating latest dependencies for .NET 6
- Update dependencies