### PR TITLE
Supports sending access token in form-encoded body or query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ All notable changes to this project will be documented in this file.
 
 ## 2.4.1 (2022-04-03)
 
-- [Avoid to override the Authorization header](https://tools.ietf.org/html/rfc6749#section-5.2)
+- [Avoid to override the Authorization header](https://www.rfc-editor.org/rfc/rfc6749#section-5.2)
 
 ## 2.4.0 (2022-04-02)
 
-- [Prefer to send the client credentials in Authorization header](https://tools.ietf.org/html/rfc6749#section-2.3.1)
+- [Prefer to send the client credentials in Authorization header](https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1)
 
 ## 2.3.1 (2021-11-14)
 
@@ -55,7 +55,7 @@ All notable changes to this project will be documented in this file.
 
 ### GSS.Authorization.OAuth2.HttpClient 2.1.0
 
-- Handle WWW-Authenticate response error (https://tools.ietf.org/html/rfc6750#section-3)
+- Handle WWW-Authenticate response error (https://www.rfc-editor.org/rfc/rfc6750#section-3)
 
 ## 2020-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.6.0 (2022-08-29)
+
+- [Supports sending access token in form-encoded body or query parameter](https://www.rfc-editor.org/rfc/rfc6750#section-2.2)
+
 ## 2.5.0 (2022-04-20)
 
 - [Use the ASP.NET Core shared framework](https://docs.microsoft.com/aspnet/core/fundamentals/target-aspnetcore#use-the-aspnet-core-shared-framework)

--- a/samples/OAuth2HttpClientSample/Program.cs
+++ b/samples/OAuth2HttpClientSample/Program.cs
@@ -37,6 +37,11 @@ static void ConfigureHttpClient(HttpClient client)
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((hostContext, services) =>
     {
+        services.AddOptions<OAuth2HttpHandlerOptions>().Configure(options =>
+        {
+            options.SendAccessTokenInBody = hostContext.Configuration.GetValue("OAuth2:SendAccessTokenInBody", false);
+            options.SendAccessTokenInQuery = hostContext.Configuration.GetValue("OAuth2:SendAccessTokenInQuery", false);
+        });
         var clientBuilder =
             hostContext.Configuration.GetValue("OAuth2:GrantFlow", "ClientCredentials")
                 .Equals("ClientCredentials", StringComparison.OrdinalIgnoreCase)

--- a/samples/OAuth2HttpClientSample/Program.cs
+++ b/samples/OAuth2HttpClientSample/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Reflection;
 using GSS.Authorization.OAuth2;
 using Microsoft.Extensions.Configuration;
@@ -17,7 +18,7 @@ static void ConfigureAuthorizerOptions(IServiceProvider resolver, AuthorizerOpti
     options.Credentials = new NetworkCredential(
         configuration["OAuth2:Credentials:UserName"],
         configuration["OAuth2:Credentials:Password"]);
-    options.Scopes = configuration.GetSection("OAuth2:Scopes").Get<IEnumerable<string>>();
+    options.Scopes = configuration["OAuth2:Scope"]?.Split(" ");
     options.OnError = (code, message) => Console.Error.Write($"ERROR: [${code}]: {message}");
 }
 
@@ -25,13 +26,14 @@ static void ConfigureHttpClient(HttpClient client)
 {
     var assembly = Assembly.GetEntryAssembly();
     var productName = assembly?.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
-    var productVersion = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? assembly?.GetName().Version?.ToString();
+    var productVersion = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
+                         assembly?.GetName().Version?.ToString();
     if (!string.IsNullOrEmpty(productName) && !string.IsNullOrEmpty(productVersion))
     {
         client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(productName, productVersion));
     }
 
-    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
 }
 
 var host = Host.CreateDefaultBuilder(args)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authorization.OAuth.HttpClient/OAuthHttpHandler.cs
+++ b/src/GSS.Authorization.OAuth.HttpClient/OAuthHttpHandler.cs
@@ -53,7 +53,7 @@ namespace GSS.Authorization.OAuth
                     }
                 }
 
-                // The form-encoded httpContent, see https://tools.ietf.org/html/rfc5849#section-3.5.2
+                // The form-encoded httpContent, see https://www.rfc-editor.org/rfc/rfc5849#section-3.5.2
                 request.Content = new FormUrlEncodedContent(values);
             }
             else if (_options.SignedAsQuery)

--- a/src/GSS.Authorization.OAuth.HttpClient/OAuthHttpHandlerOptions.cs
+++ b/src/GSS.Authorization.OAuth.HttpClient/OAuthHttpHandlerOptions.cs
@@ -26,13 +26,13 @@ namespace GSS.Authorization.OAuth
 
         /// <summary>
         /// sign request as query parameter ? (default: Authorization header)
-        /// , see https://tools.ietf.org/html/rfc5849#section-3.5.3
+        /// , see https://www.rfc-editor.org/rfc/rfc5849#section-3.5.3
         /// </summary>
         public bool SignedAsQuery { get; set; }
 
         /// <summary>
         /// sign request as form-encoded body ? (default: Authorization header)
-        /// , see https://tools.ietf.org/html/rfc5849#section-3.5.2
+        /// , see https://www.rfc-editor.org/rfc/rfc5849#section-3.5.2
         /// </summary>
         public bool SignedAsBody { get; set; }
     }

--- a/src/GSS.Authorization.OAuth/AuthorizerBase.cs
+++ b/src/GSS.Authorization.OAuth/AuthorizerBase.cs
@@ -42,7 +42,7 @@ namespace GSS.Authorization.OAuth
             var verificationCode =
                 await GetVerificationCodeAsync(authorizationUri, cancellationToken).ConfigureAwait(false);
 
-            // Step 3: Token Credentials, see https://tools.ietf.org/html/rfc5849#section-2.3
+            // Step 3: Token Credentials, see https://www.rfc-editor.org/rfc/rfc5849#section-2.3
             return await GetTokenCredentialAsync(temporaryCredentials, verificationCode, cancellationToken)
                 .ConfigureAwait(false);
         }

--- a/src/GSS.Authorization.OAuth/OAuthOptions.cs
+++ b/src/GSS.Authorization.OAuth/OAuthOptions.cs
@@ -24,17 +24,17 @@ namespace GSS.Authorization.OAuth
         public Func<string> TimestampProvider { get; set; } = () => DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// Provides the version of the authentication process as defined in this specification. see https://tools.ietf.org/html/rfc5849#section-3.1
+        /// Provides the version of the authentication process as defined in this specification. see https://www.rfc-editor.org/rfc/rfc5849#section-3.1
         /// </summary>
         public bool ProvideVersion { get; set; }
 
         /// <summary>
-        /// The realm parameter defines a protection realm per (https://tools.ietf.org/html/rfc2617). see https://tools.ietf.org/html/rfc5849#section-3.5.1
+        /// The realm parameter defines a protection realm per (https://www.rfc-editor.org/rfc/rfc2617). see https://www.rfc-editor.org/rfc/rfc5849#section-3.5.1
         /// </summary>
         public string? Realm { get; set; }
 
         /// <summary>
-        /// The Percent-Encoder, see https://tools.ietf.org/html/rfc3986#section-2.1
+        /// The Percent-Encoder, see https://www.rfc-editor.org/rfc/rfc3986#section-2.1
         /// by default, the <see cref="Uri.EscapeDataString(string)"/> is RFC3986 compliant.
         /// </summary>
         public Func<string, string> PercentEncoder { get; set; } = Uri.EscapeDataString;

--- a/src/GSS.Authorization.OAuth/Signers/HmacSha1RequestSigner.cs
+++ b/src/GSS.Authorization.OAuth/Signers/HmacSha1RequestSigner.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Primitives;
 namespace GSS.Authorization.OAuth
 {
     /// <summary>
-    /// HMAC-SHA1 signature algorithm, see https://tools.ietf.org/html/rfc5849#section-3.4.2
+    /// HMAC-SHA1 signature algorithm, see https://www.rfc-editor.org/rfc/rfc5849#section-3.4.2
     /// </summary>
     public class HmacSha1RequestSigner : RequestSignerBase
     {

--- a/src/GSS.Authorization.OAuth/Signers/PlainTextRequestSigner.cs
+++ b/src/GSS.Authorization.OAuth/Signers/PlainTextRequestSigner.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Primitives;
 namespace GSS.Authorization.OAuth
 {
     /// <summary>
-    /// PLAINTEXT signature algorithm, see https://tools.ietf.org/html/rfc5849#section-3.4.4
+    /// PLAINTEXT signature algorithm, see https://www.rfc-editor.org/rfc/rfc5849#section-3.4.4
     /// </summary>
     public class PlainTextRequestSigner : RequestSignerBase
     {

--- a/src/GSS.Authorization.OAuth/Signers/RequestSignerBase.cs
+++ b/src/GSS.Authorization.OAuth/Signers/RequestSignerBase.cs
@@ -45,7 +45,7 @@ namespace GSS.Authorization.OAuth
                 throw new ArgumentNullException(nameof(parameters));
             }
             var baseUri = GetBaseStringUri(uri);
-            // Parameters Normalization, see https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+            // Parameters Normalization, see https://www.rfc-editor.org/rfc/rfc5849#section-3.4.1.3.2
             var normalizationParameters = new List<KeyValuePair<string, string>>();
             foreach (var parameter in parameters
                 // the `oauth_signature`,`realm` parameter MUST be excluded
@@ -70,7 +70,7 @@ namespace GSS.Authorization.OAuth
         }
 
         /// <summary>
-        /// Base String URI, see https://tools.ietf.org/html/rfc5849#section-3.4.1.2
+        /// Base String URI, see https://www.rfc-editor.org/rfc/rfc5849#section-3.4.1.2
         /// </summary>
         /// <param name="uri"></param>
         /// <returns></returns>

--- a/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
+++ b/src/GSS.Authorization.OAuth2.HttpClient/GSS.Authorization.OAuth2.HttpClient.csproj
@@ -12,9 +12,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
 </Project>

--- a/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandler.cs
+++ b/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandler.cs
@@ -1,23 +1,32 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace GSS.Authorization.OAuth2
 {
     public class OAuth2HttpHandler : DelegatingHandler
     {
+        private const string ApplicationFormUrlEncoded = "application/x-www-form-urlencoded";
+        private readonly OAuth2HttpHandlerOptions _options;
         private readonly SemaphoreSlim _semaphore = new(1, 1);
         private readonly IAuthorizer _authorizer;
         private readonly IMemoryCache _memoryCache;
         private readonly string _cacheKey;
 
-        public OAuth2HttpHandler(IAuthorizer authorizer, IMemoryCache memoryCache)
+        public OAuth2HttpHandler(
+            IOptions<OAuth2HttpHandlerOptions> options,
+            IAuthorizer authorizer,
+            IMemoryCache memoryCache)
         {
+            _options = options.Value;
             _authorizer = authorizer;
             _memoryCache = memoryCache;
             _cacheKey = Guid.NewGuid().ToString();
@@ -31,16 +40,16 @@ namespace GSS.Authorization.OAuth2
             if (request.Headers.Authorization != null)
                 return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            TrySetAuthorizationHeaderToRequest(await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false),
-                request);
+            var accessToken = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
+            await SendAccessTokenInRequestAsync(accessToken, request).ConfigureAwait(false);
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            // https://tools.ietf.org/html/rfc6749#section-5.2
+            // https://www.rfc-editor.org/rfc/rfc6750#section-3
             var challenges = response.Headers.WwwAuthenticate;
             if (response.StatusCode != HttpStatusCode.Unauthorized ||
                 challenges.Any() && !challenges.Any(c => c.Scheme.Equals(AuthorizerDefaults.Bearer)))
                 return response;
-            TrySetAuthorizationHeaderToRequest(
-                await GetAccessTokenAsync(cancellationToken, forceRenew: true).ConfigureAwait(false), request);
+            accessToken = await GetAccessTokenAsync(cancellationToken, forceRenew: true).ConfigureAwait(false);
+            await SendAccessTokenInRequestAsync(accessToken, request).ConfigureAwait(false);
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
@@ -73,11 +82,35 @@ namespace GSS.Authorization.OAuth2
             }
         }
 
-        private static void TrySetAuthorizationHeaderToRequest(AccessToken accessToken, HttpRequestMessage request)
+        private async Task SendAccessTokenInRequestAsync(AccessToken accessToken, HttpRequestMessage request)
         {
             if (string.IsNullOrWhiteSpace(accessToken.Token)) return;
-            request.Headers.Authorization =
-                new AuthenticationHeaderValue(AuthorizerDefaults.Bearer, accessToken.Token);
+            if (_options.SendAccessTokenInBody && request.Content != null && string.Equals(
+                    request.Content.Headers?.ContentType?.MediaType,
+                    ApplicationFormUrlEncoded, StringComparison.OrdinalIgnoreCase))
+            {
+                var parameters =
+                    QueryHelpers.ParseQuery(await request.Content.ReadAsStringAsync().ConfigureAwait(false));
+                parameters[AuthorizerDefaults.AccessToken] = accessToken.Token;
+                var values = new List<KeyValuePair<string?, string?>>();
+                foreach (var parameter in parameters)
+                {
+                    values.AddRange(parameter.Value.Select(value =>
+                        new KeyValuePair<string?, string?>(parameter.Key, value)));
+                }
+
+                request.Content = new FormUrlEncodedContent(values);
+            }
+            else if (_options.SendAccessTokenInQuery)
+            {
+                request.RequestUri = new Uri(QueryHelpers.AddQueryString(request.RequestUri.OriginalString,
+                    AuthorizerDefaults.AccessToken, accessToken.Token));
+            }
+            else
+            {
+                request.Headers.Authorization =
+                    new AuthenticationHeaderValue(AuthorizerDefaults.Bearer, accessToken.Token);
+            }
         }
     }
 }

--- a/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandlerOptions.cs
+++ b/src/GSS.Authorization.OAuth2.HttpClient/OAuth2HttpHandlerOptions.cs
@@ -1,0 +1,17 @@
+﻿namespace GSS.Authorization.OAuth2
+{
+    public class OAuth2HttpHandlerOptions
+    {
+        /// <summary>
+        /// sending access token in query parameter ? (default: Authorization header)
+        /// , see https://www.rfc-editor.org/rfc/rfc6750#section-2.3
+        /// </summary>
+        public bool SendAccessTokenInQuery { get; set; }
+
+        /// <summary>
+        /// sending access token in form-encoded body ? (default: Authorization header)
+        /// , see https://www.rfc-editor.org/rfc/rfc6750#section-2.2
+        /// </summary>
+        public bool SendAccessTokenInBody { get; set; }
+    }
+}

--- a/src/GSS.Authorization.OAuth2.HttpClient/ServiceCollectionExtensions.cs
+++ b/src/GSS.Authorization.OAuth2.HttpClient/ServiceCollectionExtensions.cs
@@ -49,7 +49,7 @@ namespace GSS.Authorization.OAuth2
         /// Add named HttpClient with <see cref="OAuth2HttpHandler"/> and related services
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
-        /// <param name="name">The logical name of the <see cref="HttpClient"/> to configure.</param>
+        /// <param name="name">The logical name of the <see cref="System.Net.Http.HttpClient"/> to configure.</param>
         /// <typeparam name="TAuthorizer">The type of the authorizer.</typeparam>
         /// <param name="configureOptions">A delegate that is used to configure an <see cref="AuthorizerOptions"/>.</param>
         /// <param name="configureAuthorizer">A delegate that is used to configure an <see cref="T:Microsoft.Extensions.DependencyInjection.IHttpClientBuilder" /> for the <see cref="Authorizer"/>.</param>
@@ -86,8 +86,9 @@ namespace GSS.Authorization.OAuth2
         /// <typeparam name="TAuthorizer">The type of the authorizer.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <param name="configureOptions">A delegate that is used to configure an <see cref="AuthorizerOptions"/>.</param>
-        /// <returns>An <see cref="T:Microsoft.Extensions.DependencyInjection.IHttpClientBuilder" /> that can be used to configure the <see cref="AuthorizerHttpClient"/>.</returns>
-        internal static void TryAddOAuth2Authorizer<TAuthorizer>(this IServiceCollection services,
+        /// <param name="configureAuthorizer">A delegate that is used to configure an <see cref="T:Microsoft.Extensions.DependencyInjection.IHttpClientBuilder" /> for the <see cref="Authorizer"/>.</param>
+        /// <returns>An <see cref="T:Microsoft.Extensions.DependencyInjection.IHttpClientBuilder" /> that can be used to configure the <see cref="Authorizer"/>.</returns>
+        private static void TryAddOAuth2Authorizer<TAuthorizer>(this IServiceCollection services,
             Action<IServiceProvider, AuthorizerOptions> configureOptions,
             Action<IHttpClientBuilder>? configureAuthorizer = null)
             where TAuthorizer : Authorizer

--- a/src/GSS.Authorization.OAuth2.HttpClient/ServiceCollectionExtensions.cs
+++ b/src/GSS.Authorization.OAuth2.HttpClient/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace GSS.Authorization.OAuth2
 {
@@ -39,6 +40,7 @@ namespace GSS.Authorization.OAuth2
                 .AddMemoryCache()
                 .AddHttpClient<TClient>()
                 .AddHttpMessageHandler(resolver => new OAuth2HttpHandler(
+                    resolver.GetRequiredService<IOptions<OAuth2HttpHandlerOptions>>(),
                     resolver.GetRequiredService<TAuthorizer>(),
                     resolver.GetRequiredService<IMemoryCache>()));
         }
@@ -73,6 +75,7 @@ namespace GSS.Authorization.OAuth2
                 .AddMemoryCache()
                 .AddHttpClient(name)
                 .AddHttpMessageHandler(resolver => new OAuth2HttpHandler(
+                    resolver.GetRequiredService<IOptions<OAuth2HttpHandlerOptions>>(),
                     resolver.GetRequiredService<TAuthorizer>(),
                     resolver.GetRequiredService<IMemoryCache>()));
         }

--- a/src/GSS.Authorization.OAuth2/AuthorizerDefaults.cs
+++ b/src/GSS.Authorization.OAuth2/AuthorizerDefaults.cs
@@ -2,6 +2,8 @@ namespace GSS.Authorization.OAuth2
 {
     public static class AuthorizerDefaults
     {
+        public const string AccessToken = "access_token";
+        
         public const string Basic = "Basic";
         public const string Bearer = "Bearer";
 

--- a/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
+++ b/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
@@ -15,7 +15,7 @@ namespace GSS.Authorization.OAuth2
 
         [Required]
         public string ClientSecret { get; set; } = default!;
-        
+
         /*
          * send the client credentials in the request-body? (default: Authorization header)
          *

--- a/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
+++ b/src/GSS.Authorization.OAuth2/AuthorizerOptions.cs
@@ -19,7 +19,7 @@ namespace GSS.Authorization.OAuth2
         /*
          * send the client credentials in the request-body? (default: Authorization header)
          *
-         * see https://tools.ietf.org/html/rfc6749#section-2.3.1
+         * see https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
          */
         public bool SendClientCredentialsInRequestBody { get; set; }
 

--- a/test/GSS.Authorization.OAuth.HttpClient.Tests/OAuthHttpClientTests.cs
+++ b/test/GSS.Authorization.OAuth.HttpClient.Tests/OAuthHttpClientTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -59,7 +60,7 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             var options = services.GetRequiredService<IOptions<OAuthHttpHandlerOptions>>();
             var resourceUri = _configuration.GetValue<Uri>("Request:Uri");
             _mockHttp?.Expect(HttpMethod.Get, resourceUri.AbsoluteUri)
-                .WithHeaders("Authorization", _signer.GetAuthorizationHeader(
+                .WithHeaders(HeaderNames.Authorization, _signer.GetAuthorizationHeader(
                     HttpMethod.Get, resourceUri, options.Value, QueryHelpers.ParseQuery(resourceUri.Query),
                     _tokenCredentials).ToString())
                 .Respond(HttpStatusCode.OK);
@@ -89,7 +90,7 @@ namespace GSS.Authorization.OAuth.HttpClient.Tests
             var resourceUri = _configuration.GetValue<Uri>("Request:Uri");
             var basicAuth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_clientCredentials.Key}:{_clientCredentials.Secret}"));
             _mockHttp?.Expect(HttpMethod.Get, resourceUri.AbsoluteUri)
-                .WithHeaders("Authorization", $"Basic {basicAuth}")
+                .WithHeaders(HeaderNames.Authorization, $"Basic {basicAuth}")
                 .Respond(HttpStatusCode.Forbidden);
 
             // Act

--- a/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -41,7 +42,7 @@ namespace GSS.Authorization.OAuth.Tests
                         : _options.CallBack.AbsoluteUri
                 });
             _mockHttp.When(HttpMethod.Post, _options.TemporaryCredentialRequestUri.ToString())
-                .WithHeaders("Authorization", authorizationHeader.ToString())
+                .WithHeaders(HeaderNames.Authorization, authorizationHeader.ToString())
                 .Respond(new FormUrlEncodedContent(new Dictionary<string, string>
                 {
                     [OAuthDefaults.OAuthToken] = expected.Key,
@@ -102,7 +103,7 @@ namespace GSS.Authorization.OAuth.Tests
                     [OAuthDefaults.OAuthVerifier] = verificationCode
                 }, temporaryCredential);
             _mockHttp.When(HttpMethod.Post, _options.TokenRequestUri.ToString())
-                .WithHeaders("Authorization", authorizationHeader.ToString())
+                .WithHeaders(HeaderNames.Authorization, authorizationHeader.ToString())
                 .Respond(new FormUrlEncodedContent(new Dictionary<string, string>
                 {
                     [OAuthDefaults.OAuthToken] = expected.Key,
@@ -133,7 +134,7 @@ namespace GSS.Authorization.OAuth.Tests
             _options.NonceProvider = () => "walatlh";
             _options.TimestampProvider = () => "137131201";
             _mockHttp.When(HttpMethod.Post, _options.TemporaryCredentialRequestUri.ToString())
-                .WithHeaders("Authorization", _signer.GetAuthorizationHeader(HttpMethod.Post,
+                .WithHeaders(HeaderNames.Authorization, _signer.GetAuthorizationHeader(HttpMethod.Post,
                     _options.TemporaryCredentialRequestUri,
                     _options,
                     new Dictionary<string, StringValues>
@@ -155,7 +156,7 @@ namespace GSS.Authorization.OAuth.Tests
                     [OAuthDefaults.OAuthVerifier] = verificationCode
                 }, temporaryCredentials);
             _mockHttp.When(HttpMethod.Post, _options.TokenRequestUri.ToString())
-                .WithHeaders("Authorization", header.ToString())
+                .WithHeaders(HeaderNames.Authorization, header.ToString())
                 .Respond(new FormUrlEncodedContent(new Dictionary<string, string>
                 {
                     [OAuthDefaults.OAuthToken] = expected.Key,

--- a/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth.Tests/AuthorizerTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace GSS.Authorization.OAuth.Tests
 {
-    // see https://tools.ietf.org/html/rfc5849#section-1.2
+    // see https://www.rfc-editor.org/rfc/rfc5849#section-1.2
     public class AuthorizerTests
     {
         private readonly AuthorizerOptions _options = new()

--- a/test/GSS.Authorization.OAuth.Tests/RequestSignerTests.cs
+++ b/test/GSS.Authorization.OAuth.Tests/RequestSignerTests.cs
@@ -8,7 +8,7 @@ namespace GSS.Authorization.OAuth.Tests
     {
         private readonly IRequestSigner _signer = new HmacSha1RequestSigner();
 
-        // see https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+        // see https://www.rfc-editor.org/rfc/rfc5849#section-3.4.1.3.2
         [Fact]
         public void GetBaseString()
         {

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2Fixture.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2Fixture.cs
@@ -20,6 +20,10 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
         {
             handler ??= new HttpClientHandler();
             var services = new ServiceCollection();
+            services.AddOptions<OAuth2HttpHandlerOptions>().Configure(options =>
+            {
+                options.SendAccessTokenInQuery = Configuration.GetValue("OAuth2:SendAccessTokenInQuery", false);
+            });
             if (Configuration.GetValue("OAuth2:GrantFlow", "ResourceOwnerCredentials").Equals("ClientCredentials", StringComparison.OrdinalIgnoreCase))
             {
                 services.AddOAuth2HttpClient<OAuth2HttpClient, ClientCredentialsAuthorizer>(ConfigureAuthorizerOptions,

--- a/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
+++ b/test/GSS.Authorization.OAuth2.HttpClient.Tests/OAuth2HttpClientTests.cs
@@ -119,7 +119,7 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
             _mockHttp.VerifyNoOutstandingExpectation();
             _mockHttp.VerifyNoOutstandingRequest();
         }
-        
+
         [SkippableFact]
         public async Task HttpClient_AccessProtectedResourceWithUnmatchedWwwAuthenticateScheme_ShouldPassThrough()
         {
@@ -130,7 +130,7 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
                 .Respond(_ =>
                 {
                     var res = new HttpResponseMessage(HttpStatusCode.Unauthorized);
-                    res.Headers.TryAddWithoutValidation("WWW-Authenticate",
+                    res.Headers.TryAddWithoutValidation(HeaderNames.WWWAuthenticate,
                         "Basic realm=\"authentication required\"");
                     return res;
                 });
@@ -154,7 +154,7 @@ namespace GSS.Authorization.OAuth2.HttpClient.Tests
                 .Respond(_ =>
                 {
                     var res = new HttpResponseMessage(HttpStatusCode.Unauthorized);
-                    res.Headers.TryAddWithoutValidation("WWW-Authenticate",
+                    res.Headers.TryAddWithoutValidation(HeaderNames.WWWAuthenticate,
                         @"Bearer realm=""oauth2-resource"", error=""unauthorized"", error_description=""Full authentication is required to access this resource""");
                     return res;
                 });

--- a/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ClientCredentialsAuthorizerTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
+using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -41,9 +43,9 @@ namespace GSS.Authorization.OAuth2.Tests
         {
             // Arrange
             _mockHttp?.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.ClientCredentials)
-                .Respond("application/json",
+                .Respond(MediaTypeNames.Application.Json,
                     JsonSerializer.Serialize(new AccessToken
                     {
                         Token = Guid.NewGuid().ToString(), ExpiresInSeconds = 10
@@ -62,9 +64,9 @@ namespace GSS.Authorization.OAuth2.Tests
         {
             // Arrange
             _mockHttp?.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.ClientCredentials)
-                .Respond("application/json",
+                .Respond(MediaTypeNames.Application.Json,
                     JsonSerializer.Serialize(new AccessToken
                     {
                         Token = Guid.NewGuid().ToString(), ExpiresInSeconds = 10
@@ -85,7 +87,7 @@ namespace GSS.Authorization.OAuth2.Tests
 
             // Arrange
             _mockHttp.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.ClientCredentials)
                 .Respond(HttpStatusCode.InternalServerError);
 
@@ -105,9 +107,9 @@ namespace GSS.Authorization.OAuth2.Tests
             // Arrange
             var expectedErrorMessage = Guid.NewGuid().ToString();
             _mockHttp.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.ClientCredentials)
-                .Respond(HttpStatusCode.InternalServerError, "application/json", expectedErrorMessage);
+                .Respond(HttpStatusCode.InternalServerError, MediaTypeNames.Application.Json, expectedErrorMessage);
 
             // Act
             await _authorizer.GetAccessTokenAsync().ConfigureAwait(false);

--- a/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
+++ b/test/GSS.Authorization.OAuth2.Tests/ResourceOwnerCredentialsAuthorizerTests.cs
@@ -1,9 +1,11 @@
 using System.Net;
+using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using RichardSzalay.MockHttp;
 using Xunit;
 
@@ -40,11 +42,11 @@ namespace GSS.Authorization.OAuth2.Tests
         {
             // Arrange
             _mockHttp?.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
                 .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
                 .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
-                .Respond("application/json", JsonSerializer.Serialize(new AccessToken
+                .Respond(MediaTypeNames.Application.Json, JsonSerializer.Serialize(new AccessToken
                 {
                     Token = Guid.NewGuid().ToString(),
                     ExpiresInSeconds = 10
@@ -63,11 +65,11 @@ namespace GSS.Authorization.OAuth2.Tests
         {
             // Arrange
             _mockHttp?.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
                 .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
                 .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
-                .Respond("application/json", JsonSerializer.Serialize(new AccessToken
+                .Respond(MediaTypeNames.Application.Json, JsonSerializer.Serialize(new AccessToken
                 {
                     Token = Guid.NewGuid().ToString(),
                     ExpiresInSeconds = 10
@@ -88,7 +90,7 @@ namespace GSS.Authorization.OAuth2.Tests
 
             // Arrange
             _mockHttp.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
                 .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
                 .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
@@ -110,11 +112,11 @@ namespace GSS.Authorization.OAuth2.Tests
             // Arrange
             var expectedErrorMessage = Guid.NewGuid().ToString();
             _mockHttp.Expect(HttpMethod.Post, _options.AccessTokenEndpoint.AbsoluteUri)
-                .WithHeaders("Authorization", _basicAuthHeaderValue)
+                .WithHeaders(HeaderNames.Authorization, _basicAuthHeaderValue)
                 .WithFormData(AuthorizerDefaults.GrantType, AuthorizerDefaults.Password)
                 .WithFormData(AuthorizerDefaults.Username, _options.Credentials?.UserName)
                 .WithFormData(AuthorizerDefaults.Password, _options.Credentials?.Password)
-                .Respond(HttpStatusCode.InternalServerError, "application/json", expectedErrorMessage);
+                .Respond(HttpStatusCode.InternalServerError, MediaTypeNames.Application.Json, expectedErrorMessage);
 
             // Act
             await _authorizer.GetAccessTokenAsync().ConfigureAwait(false);


### PR DESCRIPTION
- https://www.rfc-editor.org/rfc/rfc6750#section-2.2