### PR TITLE
chore(deps): update NuGet packages and remove stale pins

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.5.6",
+      "version": "5.5.10",
       "commands": [
         "reportgenerator"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,12 +13,10 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
### Changes
- `coverlet.collector`: 10.0.0 → 10.0.1
- `Microsoft.NET.Test.Sdk`: 18.5.1 → 18.6.0
- `dotnet-reportgenerator-globaltool`: 5.5.6 → 5.5.10
- Remove stale `System.Net.Http` 4.3.4 and `System.Text.RegularExpressions` 4.3.1 pins (unnecessary with `CentralPackageTransitivePinningEnabled`)

### Verification
- `dotnet build -c Release` succeeded with 0 warnings/errors
- Tests pass

Refs: follows patterns from renovate/dependabot PRs