### PR TITLE
ci(nuget): enable trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ permissions:
 
 jobs:
   publish:
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,8 +28,13 @@ jobs:
         run: |
           dotnet --info
           dotnet pack -o packages
+      - name: NuGet login
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: akunzai
       - name: Publish to NuGet.org
-        run: dotnet nuget push "packages/*.nupkg" -k ${{ secrets.NUGET_AUTH_TOKEN }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "packages/*.nupkg" -k ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
   release:
     needs: publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- run NuGet publishing in the protected `production` environment
- exchange the GitHub Actions OIDC token through `NuGet/login@v1`
- publish using its short-lived API key rather than `NUGET_AUTH_TOKEN`

## Verification

- `mise exec -- actionlint .github/workflows/release.yml`
- `dotnet test`
- `dotnet pack --no-restore -o <temporary directory>`

Part of #272