### PR TITLE
chore(release): prepare 2.7.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <Nullable>enable</Nullable>
-    <Version>2.7.1-rc.0</Version>
+    <Version>2.7.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">


### PR DESCRIPTION
## Summary

- prepare the final `2.7.1` release after Trusted Publishing validation

## Verification

- `dotnet test`
- `dotnet pack --no-restore -o <temporary directory>`
- confirmed all four `.nupkg` files contain `README.md`

Closes #272